### PR TITLE
Fix repository

### DIFF
--- a/files/google.list
+++ b/files/google.list
@@ -1,2 +1,2 @@
 # Source: http://www.google.com/linuxrepositories/apt.html
-deb http://dl.google.com/linux/chrome/deb stable non-free main
+deb http://dl.google.com/linux/chrome/deb stable main


### PR DESCRIPTION
The "non-free" flag was causing the following error during "apt-get update":

W: Failed to fetch http://dl.google.com/linux/chrome/deb/dists/stable/Release  Unable to find expected entry 'non-free/binary-i386/Packages' in Release file (Wrong sources.list entry or malformed file)

Removing "non-free" fixes the problem.
